### PR TITLE
chore: remove CHANGELOG.md entry from old repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,3 @@
 ### Features
 
 * add ngx-toggle implementation ([11fa885](https://github.com/bobbyg603/ngx-toggle/commit/11fa8854ccca98cf834ce9a3ea35bda114002c5e))
-
-# 1.0.0 (2022-02-22)
-
-
-### Features
-
-* add ngx-toggle implementation ([7b92b23](https://github.com/bobbyg603/ngx-toggle/commit/7b92b23b389ccf71e360dfa766f9f2e828d4ff19))
-
-
-### Reverts
-
-* Revert "chore: merge ci.yml and cd.yml (#10)" (#11) ([cc0ea23](https://github.com/bobbyg603/ngx-toggle/commit/cc0ea237a93bd3ccac39564336dcdfd2a2994d41)), closes [#10](https://github.com/bobbyg603/ngx-toggle/issues/10) [#11](https://github.com/bobbyg603/ngx-toggle/issues/11)


### PR DESCRIPTION
I broke this repo so catastrophically badly that I had to delete it and start over 🤦. This file came from the previous repo 🪦.